### PR TITLE
Feat/multi thread msgs

### DIFF
--- a/src/crypto_signals/engine/signal_generator.py
+++ b/src/crypto_signals/engine/signal_generator.py
@@ -136,12 +136,6 @@ class SignalGenerator:
         sig_id: str,
     ) -> Signal:
         """Create a Signal object with all fields populated."""
-        # Ensure we have a date object (for logging context if needed)
-        # signal_date = (
-        #     latest.name.date()
-        #     if hasattr(latest.name, "date")
-        #     else latest.name
-        # )
 
         # Extract Prices
         close_price = float(latest["close"])
@@ -153,10 +147,7 @@ class SignalGenerator:
         if atr == 0.0 and "ATR_14" in latest:
             atr = float(latest["ATR_14"])
 
-        # --- Exit Logic ---
-
-        # 1. Invalidation (Stop Loss)
-        # Default: 1% below Low
+        # Stop Loss: 1% below Low by default
         suggested_stop = low_price * 0.99
         invalidation_price = None
 
@@ -189,15 +180,12 @@ class SignalGenerator:
             # Use general stop for now.
             pass
 
-        # 2. Take Profits (ATR Based)
-        # Entry assumed at Close (or next Open, but Close is known)
+        # Take Profits (ATR Based)
         entry_ref = close_price
 
         take_profit_1 = entry_ref + (2.0 * atr) if atr > 0 else None
         take_profit_2 = entry_ref + (4.0 * atr) if atr > 0 else None
-        # TP3: Runner (Moonbag) -> Chandelier Exit value at entry?
-        # Ideally, this updates dynamically, but we can store the
-        # initial trailing stop level.
+        # TP3: Runner using Chandelier Exit
         take_profit_3 = (
             float(latest["CHANDELIER_EXIT_LONG"])
             if "CHANDELIER_EXIT_LONG" in latest
@@ -210,8 +198,7 @@ class SignalGenerator:
         # DS is the date component of the timestamp
         ds = latest.name.date() if hasattr(latest.name, "date") else latest.name
 
-        # Confluence Factors: Scan for boolean flags
-        # Confluence Factors: Scan for boolean flags in whitelist
+        # Confluence Factors: boolean flags in whitelist
         CONFLUENCE_WHITELIST = [
             "rsi_bullish_divergence",
             "vcp_filter",

--- a/src/crypto_signals/pipelines/trade_archival.py
+++ b/src/crypto_signals/pipelines/trade_archival.py
@@ -173,8 +173,6 @@ class TradeArchivalPipeline(BigQueryPipelineBase):
 
                 # CALCULATIONS
                 # Fees: Hard to get exact without activity ID.
-                # TODO: Implement exact fee fetching via TradeActivity endpoint
-                # in Phase 4
                 fees_usd = 0.0
 
                 # PnL Calculation using ALPACA entry price (Truth) vs

--- a/src/crypto_signals/repository/firestore.py
+++ b/src/crypto_signals/repository/firestore.py
@@ -21,29 +21,9 @@ class SignalRepository:
         self.collection_name = "live_signals"
 
     def save(self, signal: Signal) -> None:
-        """
-        Save a signal to Firestore.
-
-        Uses signal_id as the document ID for idempotency.
-        Serializes the signal with ``model_dump(mode="json")`` so enums and
-        datetime-like fields become JSON-compatible values suitable for
-        Firestore storage.
-
-        Adds TTL field for automatic cleanup after 30 days.
-        Uses native Firestore Timestamp to enable Google's automatic TTL
-        policy at the database level.
-
-        Args:
-            signal: The signal to save.
-        """
-        # Convert signal to a JSON-compatible dict for Firestore storage.
+        """Save a signal to Firestore with 30-day TTL."""
         signal_data = signal.model_dump(mode="json")
-
-        # Add TTL timestamp for automatic cleanup (30 days from now)
-        # Using datetime (not string) so Firestore stores it as a native Timestamp
-        # This enables Google's automatic TTL policy in GCP Console
-        ttl_datetime = datetime.now(timezone.utc) + timedelta(days=30)
-        signal_data["expireAt"] = ttl_datetime
+        signal_data["expireAt"] = datetime.now(timezone.utc) + timedelta(days=30)
 
         doc_ref = self.db.collection(self.collection_name).document(signal.signal_id)
         doc_ref.set(signal_data)
@@ -77,22 +57,9 @@ class SignalRepository:
         return results
 
     def update_signal(self, signal: Signal) -> None:
-        """
-        Update an existing signal in Firestore.
-
-        Updates status, suggested_stop, exit_reason, and other mutable fields.
-        """
+        """Update an existing signal in Firestore (merged update)."""
         doc_ref = self.db.collection(self.collection_name).document(signal.signal_id)
-
-        # Serialize and filter for update to avoid overwriting immutable fields if desired,
-        # but full update (merge=True) ensures consistency with object state.
         signal_data = signal.model_dump(mode="json")
-
-        # Exclude creation-time fields if we want to be strict, but for now full update is safe
-        # as the object should be complete.
-        # However, we don't want to reset expireAt if we don't have to.
-        # But actually, extending expiry on active management is good.
-
         doc_ref.set(signal_data, merge=True)
 
     def update_status(self, signal_id: str, status: SignalStatus) -> None:
@@ -101,26 +68,10 @@ class SignalRepository:
         doc_ref.update({"status": status.value})
 
     def cleanup_expired_signals(self, days_old: int = 30) -> int:
-        """
-        Delete signals older than specified days.
-
-        This provides a manual cleanup mechanism in addition to the TTL field.
-        Useful for immediate cleanup or custom retention policies.
-
-        Args:
-            days_old: Delete signals older than this many days
-
-        Returns:
-            int: Number of signals deleted
-        """
+        """Delete signals older than specified days. Returns count deleted."""
         cutoff_date = datetime.now(timezone.utc) - timedelta(days=days_old)
+        logger.info(f"Cleaning up signals before {cutoff_date}")
 
-        logger.info(
-            f"Cleaning up signals older than {days_old} days (before {cutoff_date})"
-        )
-
-        # Query for old signals
-        # Note: We filter on expiration_at which is when the signal was created
         query = self.db.collection(self.collection_name).where(
             filter=FieldFilter("expiration_at", "<", cutoff_date)
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,8 +84,8 @@ def test_main_execution_flow(mock_dependencies):
 
     # Create a manager to track call order across mocks
     manager = Mock()
-    manager.attach_mock(mock_discord_instance.send_signal, 'send_signal')
-    manager.attach_mock(mock_repo_instance.save, 'save')
+    manager.attach_mock(mock_discord_instance.send_signal, "send_signal")
+    manager.attach_mock(mock_repo_instance.save, "save")
 
     # Execute
     main()
@@ -99,12 +99,10 @@ def test_main_execution_flow(mock_dependencies):
     mock_dependencies["discord"].assert_called_once()
 
     # Verify Portfolio Iteration & Asset Class Detection
-    # Verify Portfolio Iteration & Asset Class Detection
     expected_calls = [
         call("BTC/USD", AssetClass.CRYPTO, dataframe=ANY),
         call("ETH/USD", AssetClass.CRYPTO, dataframe=ANY),
         call("XRP/USD", AssetClass.CRYPTO, dataframe=ANY),
-        # Note: Equities are NOT tested here because fixture defaults to empty
     ]
     mock_gen_instance.generate_signals.assert_has_calls(expected_calls, any_order=False)
 
@@ -116,8 +114,7 @@ def test_main_execution_flow(mock_dependencies):
     # Verify thread_id was attached to signal before save
     assert mock_signal.discord_thread_id == "thread_123456"
 
-    # Verify explicit call order: Discord notification MUST happen before Firestore save
-    # This ensures thread_id is captured before persistence
+    # Verify explicit call order: Discord -> Firestore
     expected_call_order = [
         call.send_signal(mock_signal),
         call.save(mock_signal),
@@ -150,8 +147,8 @@ def test_send_signal_captures_thread_id(mock_dependencies):
 
     # Create a manager to track call order across mocks
     manager = Mock()
-    manager.attach_mock(mock_discord_instance.send_signal, 'send_signal')
-    manager.attach_mock(mock_repo_instance.save, 'save')
+    manager.attach_mock(mock_discord_instance.send_signal, "send_signal")
+    manager.attach_mock(mock_repo_instance.save, "save")
 
     # Execute
     main()
@@ -159,15 +156,7 @@ def test_send_signal_captures_thread_id(mock_dependencies):
     # Verify thread_id was attached to signal
     assert mock_signal.discord_thread_id == "mock_thread_98765"
 
-    # Verify signal was saved AFTER discord notification
-    # Note: thread_id assertion above implicitly verifies ordering since thread_id
-    # is attached after send_signal but before save. However, explicit order
-    # verification would be more robust.
-    # TODO: Use Mock.call_args_list or attach_mock to explicitly verify call order
-    mock_discord_instance.send_signal.assert_called_once_with(mock_signal)
-    mock_repo_instance.save.assert_called_once_with(mock_signal)
-
-    # Verify explicit call order: Discord notification MUST happen before Firestore save
+    # Verify explicit call order: Discord -> Firestore
     expected_call_order = [
         call.send_signal(mock_signal),
         call.save(mock_signal),


### PR DESCRIPTION
This pull request improves the reliability and observability of the signal processing workflow in `src/crypto_signals/main.py` and enhances the associated test coverage in `tests/test_main.py`. The main changes focus on adding robust error handling and structured logging for signal persistence, refining the self-healing logic for orphaned signals, and strengthening test assertions to guarantee the correct order of operations and logging outputs.

**Signal persistence improvements and logging:**

* Added timing metrics, structured logging, and robust error handling around the `repo.save(trade_signal)` call, including success/failure metrics and detailed log context for each signal persisted or failed.
* Enhanced logging when capturing Discord thread IDs for signals, adding structured context to logs for better traceability.

**Self-healing and notification logic:**

* Changed the self-healing behavior for orphaned signals: instead of creating a new Discord thread, the system now sends a recovery message to the main channel, reducing confusion and improving user experience.

**Test enhancements and reliability:**

* Updated tests to:
  - Ensure explicit call order between Discord notification and Firestore persistence using a mock manager, verifying that Discord notification always precedes persistence. [[1]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R85-R89) [[2]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R119-R137) [[3]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R151-R155) [[4]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R170-R176)
  - Add required `signal_id` attributes to test signals for structured logging and assertion accuracy. [[1]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R71) [[2]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R221) [[3]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7L222-R255)
  - Update error log assertions to match the new structured logging format for persistence failures.

**Test setup and imports:**

* Added `Mock` to test imports to support the new call order verification mechanism.