### PR TITLE
fix: managed trade implementation

### DIFF
--- a/src/crypto_signals/pipelines/trade_archival.py
+++ b/src/crypto_signals/pipelines/trade_archival.py
@@ -151,7 +151,9 @@ class TradeArchivalPipeline(BigQueryPipelineBase):
                 # This is the price we *intended* to enter at
                 # Use target_entry_price if available, fallback to entry_fill_price for legacy
                 target_price = float(
-                    pos.get("target_entry_price") or pos.get("entry_fill_price", 0.0)
+                    pos.get("target_entry_price")
+                    if pos.get("target_entry_price") is not None
+                    else pos.get("entry_fill_price", 0.0)
                 )
 
                 # Broker's order ID for auditability (links to Alpaca dashboard)


### PR DESCRIPTION
This pull request introduces a new synchronization step for open trading positions, ensuring the application's position data stays consistent with the Alpaca broker's state. It also improves the archival pipeline by supporting a new field for target entry price, increasing data accuracy and backward compatibility.

**Position synchronization improvements:**

* Added a "position sync loop" in `main.py` that checks all open positions using `PositionRepository` and updates their status and leg IDs based on the latest broker data, handling externally closed positions and logging results.
* Imported `PositionRepository` and instantiated it in the main application flow to support the new sync functionality. [[1]](diffhunk://#diff-f52765b4b03ef8476e98d8d121e508588715db1188924fa7f0ea706f7fbdd946L37-R37) [[2]](diffhunk://#diff-f52765b4b03ef8476e98d8d121e508588715db1188924fa7f0ea706f7fbdd946R100)

**Trade archival enhancements:**

* Modified the `trade_archival` pipeline to use `target_entry_price` if available, falling back to `entry_fill_price` for legacy data, improving accuracy and compatibility with older records.