### PR TITLE
fix: correct docker run command syntax for smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
             -e DISCORD_BOT_TOKEN=${{ secrets.DISCORD_BOT_TOKEN }} \
             -e CRYPTO_SYMBOLS="${{ vars.CRYPTO_SYMBOLS }}" \
             "$IMAGE_SHA" \
-            --smoke-test
+            python -m crypto_signals.main --smoke-test
 
           echo "✅ Container validation complete"
 


### PR DESCRIPTION
Docker replaces CMD when args are provided, not appends. Changed from '--smoke-test' to 'python -m crypto_signals.main --smoke-test'