### PR TITLE
feat: add GitHub Actions workflow for CI/CD, Cloud Run deployment, and monitoring.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,7 +220,7 @@ jobs:
           gcloud run jobs execute crypto-signals-job \
             --region=${{ vars.GCP_REGION }} \
             --update-env-vars TEST_MODE=true,DISABLE_SECRET_MANAGER=true \
-            --args="--smoke-test" \
+            --args="python,-m,crypto_signals.main,--smoke-test" \
             --wait
 
       - name: Auto-Rollback on Failure


### PR DESCRIPTION
This pull request makes a small adjustment to the deployment workflow for the crypto-signals job. The change updates the way arguments are passed to the job, ensuring the main module is invoked explicitly with Python.

- Updated the `gcloud run jobs execute` command in `.github/workflows/deploy.yml` to use `python -m crypto_signals.main` as the entry point, instead of passing `--smoke-test` directly.