### PR TITLE
Enforce partitioning and clustering in SchemaGuardian (#185)

### DIFF
--- a/src/crypto_signals/engine/schema_guardian.py
+++ b/src/crypto_signals/engine/schema_guardian.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List, Type
+from typing import Any, List, Optional, Type
 
 from google.cloud import bigquery
 from loguru import logger
@@ -32,7 +32,11 @@ class SchemaGuardian:
         self.strict_mode = strict_mode
 
     def validate_schema(
-        self, table_id: str, model: Type[BaseModel]
+        self,
+        table_id: str,
+        model: Type[BaseModel],
+        require_partitioning: bool = False,
+        clustering_fields: Optional[List[str]] = None,
     ) -> tuple[List[tuple[str, str]], List[str]]:
         """
         Validates that the BigQuery table schema matches the Pydantic model.
@@ -40,6 +44,8 @@ class SchemaGuardian:
         Args:
             table_id: Full table ID (project.dataset.table)
             model: Pydantic model class
+            require_partitioning: Enforce that the table is partitioned (Time or Range).
+            clustering_fields: Enforce exact match of clustering fields.
 
         Returns:
             A tuple containing:
@@ -56,7 +62,28 @@ class SchemaGuardian:
             model.model_fields.items(), table.schema
         )
 
-        if missing_columns or type_mismatches:
+        # --- New Checks (Partitioning & Clustering) ---
+        partitioning_error = None
+        if require_partitioning:
+            # Check for either TimePartitioning or RangePartitioning
+            if not (table.time_partitioning or table.range_partitioning):
+                partitioning_error = "Table is not partitioned"
+
+        clustering_error = None
+        if clustering_fields is not None:
+            # table.clustering_fields returns a list of strings or None
+            actual_clustering = table.clustering_fields or []
+            if actual_clustering != clustering_fields:
+                clustering_error = (
+                    f"Clustering mismatch: Expected {clustering_fields}, Found {actual_clustering}"
+                )
+
+        if (
+            missing_columns
+            or type_mismatches
+            or partitioning_error
+            or clustering_error
+        ):
             # Format the error messages for logging, but return the structured data
             error_messages = []
             if missing_columns:
@@ -66,6 +93,10 @@ class SchemaGuardian:
                 error_messages.append(f"Missing columns: {', '.join(formatted_missing)}")
             if type_mismatches:
                 error_messages.append(f"Type mismatch: {', '.join(type_mismatches)}")
+            if partitioning_error:
+                error_messages.append(partitioning_error)
+            if clustering_error:
+                error_messages.append(clustering_error)
 
             full_error = f"Schema Validation Failed for {table_id}: " + "; ".join(
                 error_messages

--- a/src/crypto_signals/pipelines/account_snapshot.py
+++ b/src/crypto_signals/pipelines/account_snapshot.py
@@ -282,6 +282,16 @@ class AccountSnapshotPipeline(BigQueryPipelineBase):
         logger.info(f"[{self.job_name}] Starting pipeline execution...")
 
         try:
+            # 0. Pre-flight Check: Validate Schema
+            logger.info(f"[{self.job_name}] Validating BigQuery Schema...")
+            # The guardian will raise an exception if strict_mode is True and there's a mismatch
+            self.guardian.validate_schema(
+                table_id=self.fact_table_id,
+                model=self.schema_model,
+                require_partitioning=True,
+                clustering_fields=self.clustering_fields,
+            )
+
             # 1. Extract
             raw_data = self.extract()
             if not raw_data:

--- a/tests/pipelines/test_account_snapshot.py
+++ b/tests/pipelines/test_account_snapshot.py
@@ -259,11 +259,14 @@ def test_pipeline_run_skip_cleanup(pipeline):
         patch.object(pipeline, "_load_to_staging"),
         patch.object(pipeline, "_execute_merge"),
         patch.object(pipeline, "cleanup") as mock_clean,
+        # Mock guardian validation to avoid schema errors during test
+        patch.object(pipeline.guardian, "validate_schema") as mock_validate,
     ):
         mock_ext.return_value = ["raw"]
         mock_trans.return_value = ["processed"]
 
         pipeline.run()
 
+        mock_validate.assert_called_once()
         mock_ext.assert_called_once()
         mock_clean.assert_not_called()

--- a/tests/pipelines/test_schema_guardian_integration.py
+++ b/tests/pipelines/test_schema_guardian_integration.py
@@ -65,7 +65,10 @@ def test_pipeline_validates_schema_before_running(pipeline):
 
     # Assert validation was called with correct args
     pipeline.mock_guardian_instance.validate_schema.assert_called_once_with(
-        table_id="proj.ds.fact", model=MockModel
+        table_id="proj.ds.fact",
+        model=MockModel,
+        require_partitioning=True,
+        clustering_fields=None,
     )
 
 
@@ -98,3 +101,22 @@ def test_pipeline_fails_on_schema_mismatch(pipeline):
         pipeline.run()
 
     pipeline.extract.assert_not_called()
+
+
+def test_pipeline_validates_clustering(pipeline):
+    """Test that pipeline calls guardian with clustering_fields."""
+    # We need to re-instantiate or modify pipeline to have clustering_fields
+    pipeline.clustering_fields = ["id"]
+
+    # Mock extract
+    pipeline.extract = MagicMock(return_value=[])
+
+    pipeline.run()
+
+    instance = pipeline.mock_guardian_instance
+    instance.validate_schema.assert_called_with(
+        table_id="proj.ds.fact",
+        model=MockModel,
+        require_partitioning=True,
+        clustering_fields=["id"],
+    )


### PR DESCRIPTION
Updated `SchemaGuardian` and pipelines to enforce partitioning and clustering.

- Updated `SchemaGuardian.validate_schema` to accept `require_partitioning` and `clustering_fields`.
- Added logic to check `table.time_partitioning`, `table.range_partitioning`, and `table.clustering_fields`.
- Updated `BigQueryPipelineBase` to accept `clustering_fields` in `__init__` and pass `require_partitioning=True` and `clustering_fields` to `validate_schema`.
- Updated `AccountSnapshotPipeline` to include schema validation in its overridden `run` method.
- Added tests for new functionality in `tests/engine/test_schema_guardian.py` and `tests/pipelines/test_schema_guardian_integration.py`.

---
*PR created automatically by Jules for task [1323967039105979380](https://jules.google.com/task/1323967039105979380) started by @lagarcess*