### PR TITLE
Formalize Defaults in StrategyConfig for Robustness

### DIFF
--- a/src/crypto_signals/domain/schemas.py
+++ b/src/crypto_signals/domain/schemas.py
@@ -254,6 +254,14 @@ class StrategyConfig(BaseModel):
         default_factory=dict,
         description="Risk management parameters (stop_loss_pct, take_profit_pct, etc.)",
     )
+    confluence_config: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Configuration for confluence factors (e.g. {rsi_period: 14})",
+    )
+    pattern_overrides: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Overrides for specific patterns (e.g. {bullish_engulfing: {priority: 1}})",
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
Added `confluence_config` and `pattern_overrides` to `StrategyConfig` schema to support complex strategy configurations and ensure robustness against missing fields in Firestore. Verified with new tests covering defaults, explicit values, and JSON serialization.

---
*PR created automatically by Jules for task [2281201119552553631](https://jules.google.com/task/2281201119552553631) started by @lagarcess*