### PR TITLE
fix: handle race conditions in SchemaGuardian table creation (#262)

### DIFF
--- a/tests/engine/test_schema_guardian.py
+++ b/tests/engine/test_schema_guardian.py
@@ -2,6 +2,7 @@ from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
+from google.api_core.exceptions import Conflict
 from crypto_signals.engine.schema_guardian import SchemaGuardian, SchemaMismatchError
 from google.cloud import bigquery
 from pydantic import BaseModel
@@ -233,6 +234,18 @@ def test_validate_schema_clustering_mismatch(guardian, mock_bq_client):
         )
 
     assert "Clustering mismatch" in str(exc.value)
+
+
+def test_create_table_race_condition(guardian, mock_bq_client):
+    """Test that 409 Conflict (race condition) is handled gracefully."""
+    # Mock create_table to raise Conflict
+    mock_bq_client.create_table.side_effect = Conflict("Table exists")
+
+    # Should not raise exception
+    guardian._create_table("project.dataset.table", SimpleModel)
+
+    # Verify create_table was attempted
+    mock_bq_client.create_table.assert_called_once()
 
 
 def test_validate_schema_clustering_missing_on_table(guardian, mock_bq_client):


### PR DESCRIPTION
Added regression test for handling 409 Conflict during table creation in SchemaGuardian. The implementation already handled the conflict, but the test ensures this behavior is preserved.

---
*PR created automatically by Jules for task [15744730816295745699](https://jules.google.com/task/15744730816295745699) started by @lagarcess*