### PR TITLE
Fix CI/CD Concurrency Cancellation & Discord Webhook Metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -267,11 +267,18 @@ jobs:
           CI_STATUS="${{ needs.ci.result }}"
           VAL_STATUS="${{ needs.validate-deployment.result }}"
           CD_STATUS="${{ needs.cd.result }}"
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
 
           if [[ "$CI_STATUS" == "failure" || "$VAL_STATUS" == "failure" || "$CD_STATUS" == "failure" ]]; then
              COLOR="15158332" # Red
              EMOJI="🚨"
              FINAL_STATUS="FAILED"
+          elif [[ "$CI_STATUS" == "cancelled" || "$VAL_STATUS" == "cancelled" || "$CD_STATUS" == "cancelled" ]]; then
+             COLOR="8421504" # Gray
+             EMOJI="⚪"
+             FINAL_STATUS="CANCELLED"
+          # Note: We don't explicitly check for 'skipped' here to avoid false positives
+          # from jobs that are expectedly skipped (like validation on push).
           else
              COLOR="3066993" # Green
              EMOJI="✅"
@@ -299,7 +306,8 @@ jobs:
                 {"name": "2. Validation", "value": "$(status_emoji $VAL_STATUS)", "inline": true},
                 {"name": "3. Deployment", "value": "$(status_emoji $CD_STATUS)", "inline": true},
                 {"name": "Author", "value": "${{ github.actor }}", "inline": true},
-                {"name": "Commit", "value": "${{ github.sha }}", "inline": false}
+                {"name": "Commit", "value": "[$SHORT_SHA](https://github.com/${{ github.repository }}/commit/${{ github.sha }})", "inline": true},
+                {"name": "Run ID", "value": "[${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})", "inline": true}
               ]
             }]
           }


### PR DESCRIPTION
This PR improves the CI/CD pipeline by correctly handling workflow cancellation and enhancing the Discord notifications with better traceability metadata.

Key changes:
1.  **Status Logic Fix**: The `notify` job now explicitly checks for a `cancelled` status from the preceding jobs. Previously, it would default to reporting 'SUCCESS' if a job was cancelled by the concurrency group.
2.  **Metadata Injection**: Added the `${{ github.run_id }}` to the Discord notification payload.
3.  **Traceability Links**: Both the `Commit` and `Run ID` are now formatted as markdown links to the respective GitHub pages.
4.  **UI Improvements**: The commit SHA is now truncated to 7 characters, and fields are arranged as inline to optimize space in the Discord embed.
5.  **Documentation**: Added a note in the workflow file explaining why 'skipped' is not explicitly flagged as 'CANCELLED' to avoid false positives from conditionally skipped jobs.

Fixes #328

---
*PR created automatically by Jules for task [18044282140074100285](https://jules.google.com/task/18044282140074100285) started by @lagarcess*