### PR TITLE
feat(schema): expand FactTheoreticalSignal for unified backtesting (#360)

### DIFF
--- a/docs/designs/analytics_gap_analysis.md
+++ b/docs/designs/analytics_gap_analysis.md
@@ -49,6 +49,46 @@ Instead of sharding signals into four tables (`rejected`, `expired`, `executed`,
 	- Every `REJECTED`, `EXPIRED`, `INVALIDATED`, and **`EXECUTED/CLOSED`** signal will be archived here.
 	- This creates a massive, singular dataset for analysts to query true market history without survivorship bias or multi-table `UNION` joins. Reconciling financial performance with technical indicators is a simple `JOIN` between `fact_trades.trade_id` and `fact_theoretical_signals.signal_id`.
 
+	**Consolidated Field List** (Pydantic: `FactTheoreticalSignal`, Issue #360):
+
+	| Section | Field | Type | Required | Notes |
+	|---|---|---|---|---|
+	| Core Identity | `doc_id` | `str` | No | Firestore document ID |
+	| | `ds` | `date` | **Yes** | Partition key |
+	| | `signal_id` | `str` | **Yes** | Deterministic UUID5 |
+	| | `strategy_id` | `str` | **Yes** | FK to dim_strategies |
+	| | `symbol` | `str` | **Yes** | e.g., `BTC/USD` |
+	| | `asset_class` | `AssetClass` | **Yes** | CRYPTO / EQUITY |
+	| | `side` | `OrderSide` | **Yes** | BUY / SELL |
+	| Outcome | `status` | `SignalStatus` | **Yes** | EXPIRED, REJECTED_BY_FILTER, etc. |
+	| | `trade_type` | `str` | **Yes** | EXECUTED, FILTERED, THEORETICAL, RISK_BLOCKED |
+	| | `exit_reason` | `ExitReason` | No | TP1, STOP_LOSS, etc. |
+	| | `rejection_reason` | `str` | No | Quality gate failure description |
+	| Signal Params | `entry_price` | `float` | **Yes** | Target entry price |
+	| | `pattern_name` | `str` | **Yes** | e.g., `bullish_engulfing` |
+	| | `suggested_stop` | `float` | **Yes** | Stop-loss price |
+	| | `take_profit_1/2/3` | `float` | No | Profit targets |
+	| | `valid_until` | `datetime` | **Yes** | Signal expiration |
+	| | `created_at` | `datetime` | **Yes** | Signal creation time |
+	| Structural | `pattern_classification` | `str` | No | STANDARD / MACRO |
+	| | `pattern_duration_days` | `int` | No | First pivot → signal |
+	| | `pattern_span_days` | `int` | No | First → last pivot |
+	| | `conviction_tier` | `str` | No | HIGH / STANDARD |
+	| | `structural_context` | `str` | No | Harmonic regime |
+	| Nested (ADR #359) | `confluence_factors` | `List[str]` | No (default `[]`) | Triggers list |
+	| | `confluence_snapshot` | `STRING` (JSON) | No | Indicator values |
+	| | `harmonic_metadata` | `STRING` (JSON) | No | Fibonacci ratios |
+	| | `rejection_metadata` | `STRING` (JSON) | No | Forensic audit data |
+	| | `structural_anchors` | `REPEATED RECORD` | No | Pivot geometry |
+	| Theoretical P&L | `theoretical_exit_price` | `float` | No | Simulated exit |
+	| | `theoretical_exit_reason` | `str` | No | Simulated exit reason |
+	| | `theoretical_exit_time` | `datetime` | No | Simulated exit time |
+	| | `theoretical_pnl_usd` | `float` | No | Simulated P&L ($) |
+	| | `theoretical_pnl_pct` | `float` | No | Simulated P&L (%) |
+	| | `theoretical_fees_usd` | `float` | No | Simulated fees |
+	| Near-Miss | `distance_to_trigger_pct` | `float` | No | Entry proximity |
+	| FK | `linked_trade_id` | `str` | No | FK to fact_trades (EXECUTED only) |
+
 ### 2. Radical Virtualization (Temp Tables)
 We will eradicate the 14+ persistent `stg_` tables currently cluttering BigQuery.
 - The base `BigQueryPipelineBase` Python framework will be refactored. Instead of using `client.load_table_from_json()` targeting a persistent `dataset.stg_table`, the pipeline will build a `CREATE TEMP TABLE stg_temp AS ...` SQL injection payload dynamically.

--- a/src/crypto_signals/domain/schemas.py
+++ b/src/crypto_signals/domain/schemas.py
@@ -18,6 +18,7 @@ from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional
 
+from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 # =============================================================================
@@ -1020,11 +1021,16 @@ class StructuralAnchor(BaseModel):
 
 class FactTheoreticalSignal(BaseModel):
     """
-    Unified backtesting super-table schema for all theoretical signals.
+    Unified backtesting record for BigQuery fact_theoretical_signals table.
 
-    Replaces ExpiredSignal, RejectedSignal, and captures invalidations.
+    Captures ALL signal outcomes: REJECTED_BY_FILTER, EXPIRED, INVALIDATED,
+    and the parent live_signal of EXECUTED trades (for ML indicator preservation).
+
+    Partitioned by: ds | Clustered by: status, strategy_id, symbol
+    FK to fact_trades: linked_trade_id (EXECUTED signals only)
     """
 
+    # === Core Identity ===
     doc_id: Optional[str] = Field(None, description="Firestore document ID")
     ds: date = Field(..., description="Partition key - date signal was generated")
     signal_id: str = Field(..., description="Unique identifier for the signal")
@@ -1032,16 +1038,71 @@ class FactTheoreticalSignal(BaseModel):
     symbol: str = Field(..., description="Asset symbol")
     asset_class: AssetClass = Field(..., description="Asset class (CRYPTO or EQUITY)")
     side: OrderSide = Field(..., description="Signal side (buy or sell)")
+
+    # === Outcome Classification ===
+    status: SignalStatus = Field(
+        ...,
+        description="Final status (e.g., EXPIRED, REJECTED_BY_FILTER, INVALIDATED, EXECUTED)",
+    )
+    trade_type: str = Field(
+        ...,
+        description="Trade classification: EXECUTED, FILTERED, THEORETICAL, RISK_BLOCKED",
+    )
+    exit_reason: Optional[ExitReason] = Field(
+        default=None, description="Reason for trade exit"
+    )
+    rejection_reason: Optional[str] = Field(
+        default=None,
+        description="Reason for rejection if status is REJECTED_BY_FILTER",
+    )
+
+    # === Signal Parameters ===
     entry_price: float = Field(..., description="Target entry price of the signal")
+    pattern_name: str = Field(
+        ..., description="Name of the pattern detected (e.g., 'bullish_engulfing')"
+    )
     suggested_stop: float = Field(..., description="Suggested stop-loss for the signal")
+    take_profit_1: Optional[float] = Field(
+        default=None, description="First profit target (Conservative)"
+    )
+    take_profit_2: Optional[float] = Field(
+        default=None, description="Second profit target (Structural)"
+    )
+    take_profit_3: Optional[float] = Field(
+        default=None, description="Third profit target / trailing stop"
+    )
     valid_until: datetime = Field(
         ..., description="When the signal expired or was executed"
     )
-    status: SignalStatus = Field(
-        ..., description="Final status (e.g., EXPIRED, REJECTED_BY_FILTER, EXECUTED)"
+    created_at: datetime = Field(..., description="When the signal was first created")
+
+    # === Structural Metadata ===
+    pattern_classification: Optional[str] = Field(
+        default=None,
+        description="Pattern scale: 'STANDARD_PATTERN' or 'MACRO_PATTERN'",
+    )
+    pattern_duration_days: Optional[int] = Field(
+        default=None,
+        description="Duration in days from first pivot to signal",
+    )
+    pattern_span_days: Optional[int] = Field(
+        default=None,
+        description="Time span from first to last structural pivot",
+    )
+    conviction_tier: Optional[str] = Field(
+        default=None,
+        description="Signal conviction: 'HIGH' or 'STANDARD'",
+    )
+    structural_context: Optional[str] = Field(
+        default=None,
+        description="Active harmonic/structural regime",
     )
 
-    # Nested fields mapped explicitly for BigQuery
+    # === Nested Fields — types per ADR #359 ===
+    confluence_factors: List[str] = Field(
+        default_factory=list,
+        description="List of triggers/patterns (e.g., 'RSI_DIV', 'VCP_COMPRESSION')",
+    )
     confluence_snapshot: Optional[Dict[str, Any]] = Field(
         default=None,
         description="JSON blob of indicator values at rejection",
@@ -1050,16 +1111,82 @@ class FactTheoreticalSignal(BaseModel):
         default=None,
         description="JSON blob of Harmonic pattern ratios",
     )
-    structural_anchors: Optional[List[StructuralAnchor]] = Field(
-        default=None,
-        description="REPEATED RECORD mapping for list of structural pivots",
-    )
     rejection_metadata: Optional[Dict[str, Any]] = Field(
         default=None,
         description="JSON blob for validation forensic failures",
     )
+    structural_anchors: Optional[List[StructuralAnchor]] = Field(
+        default=None,
+        description="REPEATED RECORD mapping for list of structural pivots",
+    )
 
-    created_at: datetime = Field(..., description="When the signal was first created")
+    # === Theoretical P&L ===
+    theoretical_exit_price: Optional[float] = Field(
+        default=None, description="Simulated exit price"
+    )
+    theoretical_exit_reason: Optional[str] = Field(
+        default=None, description="Simulated exit reason"
+    )
+    theoretical_exit_time: Optional[datetime] = Field(
+        default=None, description="Simulated exit timestamp"
+    )
+    theoretical_pnl_usd: Optional[float] = Field(
+        default=None, description="Simulated P&L in USD"
+    )
+    theoretical_pnl_pct: Optional[float] = Field(
+        default=None, description="Simulated P&L as percentage"
+    )
+    theoretical_fees_usd: Optional[float] = Field(
+        default=None, description="Simulated fees in USD"
+    )
+
+    # === Near-Miss ===
+    distance_to_trigger_pct: Optional[float] = Field(
+        default=None,
+        description="Percentage distance from entry to trigger for expired signals",
+    )
+
+    # === FK to fact_trades (EXECUTED signals only) ===
+    linked_trade_id: Optional[str] = Field(
+        default=None,
+        description="Foreign key to fact_trades for EXECUTED signals",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_json_blob_fields(cls, data: Any) -> Any:
+        """Parse JSON string fields into dictionaries before validation.
+
+        This `before` validator allows callers to initialize the model with
+        pre-serialized JSON strings for `confluence_snapshot`,
+        `harmonic_metadata`, and `rejection_metadata`. It attempts to parse
+        these strings into Python dictionaries, enabling convenient attribute
+        access on the model instance.
+
+        If a string is not valid JSON, it is left as-is, and Pydantic's
+        standard validation will likely raise an error for the type mismatch.
+
+        The reverse operation (dict -> JSON string for BigQuery) is handled by
+        the `@field_serializer` for these fields.
+        """
+        if isinstance(data, dict):
+            for field_name in (
+                "confluence_snapshot",
+                "harmonic_metadata",
+                "rejection_metadata",
+            ):
+                value = data.get(field_name)
+                if isinstance(value, str):
+                    # Parse JSON string back to dict for Python-side access
+                    try:
+                        data[field_name] = json.loads(value)
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning(
+                            "Failed to decode JSON string for field "
+                            f"'{field_name}'. The value will be passed "
+                            "to validation as a string."
+                        )
+        return data
 
     @field_serializer(
         "confluence_snapshot",
@@ -1075,10 +1202,12 @@ class FactTheoreticalSignal(BaseModel):
 
 class ExpiredSignal(BaseModel):
     """
-    Archived expired signal for BigQuery analytics.
+    DEPRECATED: Superseded by FactTheoreticalSignal (Issue #360).
+    Will be removed after BacktestArchivalPipeline (Issue #361) is validated in prod.
+    Do not add new fields. See GitHub #360.
 
-    Stored in the fact_signals_expired table. Used for analyzing signal
-    sensitivity and "near misses".
+    Archived expired signal for BigQuery analytics.
+    Stored in the fact_signals_expired table.
     """
 
     doc_id: Optional[str] = Field(None, description="Firestore document ID")
@@ -1103,8 +1232,11 @@ class ExpiredSignal(BaseModel):
 
 class FactRejectedSignal(BaseModel):
     """
-    Schema for rejected signals archival (Fact Table).
+    DEPRECATED: Superseded by FactTheoreticalSignal (Issue #360).
+    Will be removed after BacktestArchivalPipeline (Issue #361) is validated in prod.
+    Do not add new fields. See GitHub #360.
 
+    Schema for rejected signals archival (Fact Table).
     This matches the `fact_rejected_signals` BigQuery table.
     """
 

--- a/tests/domain/test_schemas.py
+++ b/tests/domain/test_schemas.py
@@ -455,12 +455,118 @@ class TestStrategyConfigDefaults:
 
 
 # =============================================================================
-# FACT THEORETICAL SIGNAL (BQ NESTED FIELDS)
+# FACT THEORETICAL SIGNAL (Issue #360 — Unified Backtesting Schema)
 # =============================================================================
 
 
 class TestFactTheoreticalSignal:
-    """Tests for BigQuery schema serialization of FactTheoreticalSignal."""
+    """Tests for the unified FactTheoreticalSignal schema (Issue #360).
+
+    Covers all 4 signal outcome scenarios, dict-to-JSON coercion,
+    and BigQuery serialization.
+    """
+
+    @pytest.mark.parametrize(
+        "overrides,expected_status,expected_key_field",
+        [
+            pytest.param(
+                {
+                    "status": SignalStatus.REJECTED_BY_FILTER,
+                    "trade_type": "FILTERED",
+                    "rejection_reason": "Volume 1.2x < 1.5x Required",
+                    "confluence_snapshot": {"rsi": 30.5, "adx": 18.0},
+                },
+                SignalStatus.REJECTED_BY_FILTER,
+                "rejection_reason",
+                id="rejected",
+            ),
+            pytest.param(
+                {
+                    "status": SignalStatus.EXPIRED,
+                    "trade_type": "FILTERED",
+                    "distance_to_trigger_pct": 2.5,
+                    "theoretical_pnl_usd": -150.0,
+                    "theoretical_pnl_pct": -0.3,
+                },
+                SignalStatus.EXPIRED,
+                "distance_to_trigger_pct",
+                id="expired",
+            ),
+            pytest.param(
+                {
+                    "status": SignalStatus.INVALIDATED,
+                    "trade_type": "THEORETICAL",
+                    "exit_reason": ExitReason.STRUCTURAL_INVALIDATION,
+                },
+                SignalStatus.INVALIDATED,
+                "exit_reason",
+                id="invalidated",
+            ),
+            pytest.param(
+                {
+                    "status": SignalStatus.TP1_HIT,
+                    "trade_type": "EXECUTED",
+                    "linked_trade_id": "trade-abc-123",
+                    "harmonic_metadata": {"B_ratio": 0.618},
+                    "conviction_tier": "HIGH",
+                },
+                SignalStatus.TP1_HIT,
+                "linked_trade_id",
+                id="executed",
+            ),
+        ],
+    )
+    def test_signal_outcome_scenarios(
+        self, overrides, expected_status, expected_key_field
+    ):
+        """Verify FactTheoreticalSignal handles all 4 signal outcome types."""
+        from tests.factories import FactTheoreticalSignalFactory
+
+        signal = FactTheoreticalSignalFactory.build(**overrides)
+
+        assert (
+            signal.status == expected_status
+        ), f"Expected status={expected_status!r}, got {signal.status!r}"
+        key_value = getattr(signal, expected_key_field)
+        expected_value = overrides.get(expected_key_field)
+        assert (
+            key_value == expected_value
+        ), f"Expected {expected_key_field}={expected_value!r}, got {key_value!r}"
+
+    def test_dict_to_json_coercion_on_input(self):
+        """Verify that dict inputs for JSON blob fields are preserved as dicts in Python."""
+        from tests.factories import FactTheoreticalSignalFactory
+
+        snapshot_dict = {"rsi": 45.2, "adx": 28.0, "volume_ratio": 1.8}
+        signal = FactTheoreticalSignalFactory.build(
+            confluence_snapshot=snapshot_dict,
+        )
+
+        # Python-side: remains dict for attribute access
+        assert isinstance(
+            signal.confluence_snapshot, dict
+        ), f"Expected confluence_snapshot to be dict, got {type(signal.confluence_snapshot)}"
+        assert (
+            signal.confluence_snapshot["rsi"] == 45.2
+        ), f"Expected rsi=45.2, got {signal.confluence_snapshot.get('rsi')!r}"
+
+    def test_json_string_input_coercion(self):
+        """Verify that JSON string inputs for blob fields are parsed to dicts."""
+        from tests.factories import FactTheoreticalSignalFactory
+
+        json_str = '{"rsi": 55.0, "adx": 30.0}'
+        signal = FactTheoreticalSignalFactory.build(
+            confluence_snapshot=json_str,
+        )
+
+        # model_validator should parse JSON string to dict
+        assert isinstance(signal.confluence_snapshot, dict), (
+            f"Expected confluence_snapshot to be dict after coercion, "
+            f"got {type(signal.confluence_snapshot)}"
+        )
+        assert (
+            signal.confluence_snapshot["rsi"] == 55.0
+        ), f"Expected rsi=55.0, got {signal.confluence_snapshot.get('rsi')!r}"
 
     def test_bq_serialization_of_nested_fields(self):
         """Ensure nested fields serialize properly to BQ-compatible primitives via model_dump."""
@@ -475,9 +581,11 @@ class TestFactTheoreticalSignal:
             asset_class=AssetClass.CRYPTO,
             side=OrderSide.BUY,
             entry_price=50000.0,
+            pattern_name="bullish_engulfing",
             suggested_stop=48000.0,
             valid_until=datetime(2024, 1, 16, tzinfo=timezone.utc),
             status=SignalStatus.EXPIRED,
+            trade_type="FILTERED",
             created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
             confluence_snapshot={"rsi": 30.5, "adx": 25.0},
             harmonic_metadata={"B_ratio": 0.618},
@@ -495,23 +603,40 @@ class TestFactTheoreticalSignal:
         serialized = signal.model_dump(mode="json")
 
         # STRING (JSON Blob) mapping tests
-        assert isinstance(serialized["confluence_snapshot"], str)
+        assert isinstance(
+            serialized["confluence_snapshot"], str
+        ), f"Expected confluence_snapshot as str, got {type(serialized['confluence_snapshot'])}"
         deserialized_confluence = json.loads(serialized["confluence_snapshot"])
-        assert deserialized_confluence["rsi"] == 30.5
+        assert (
+            deserialized_confluence["rsi"] == 30.5
+        ), f"Expected rsi=30.5, got {deserialized_confluence.get('rsi')!r}"
 
-        assert isinstance(serialized["harmonic_metadata"], str)
+        assert isinstance(
+            serialized["harmonic_metadata"], str
+        ), f"Expected harmonic_metadata as str, got {type(serialized['harmonic_metadata'])}"
         deserialized_harmonic = json.loads(serialized["harmonic_metadata"])
-        assert deserialized_harmonic["B_ratio"] == 0.618
+        assert (
+            deserialized_harmonic["B_ratio"] == 0.618
+        ), f"Expected B_ratio=0.618, got {deserialized_harmonic.get('B_ratio')!r}"
 
-        assert isinstance(serialized["rejection_metadata"], str)
+        assert isinstance(
+            serialized["rejection_metadata"], str
+        ), f"Expected rejection_metadata as str, got {type(serialized['rejection_metadata'])}"
         deserialized_rejection = json.loads(serialized["rejection_metadata"])
-        assert deserialized_rejection["reason"] == "volume_too_low"
+        assert (
+            deserialized_rejection["reason"] == "volume_too_low"
+        ), f"Expected reason='volume_too_low', got {deserialized_rejection.get('reason')!r}"
 
         # REPEATED RECORD mapping check
-        assert isinstance(serialized["structural_anchors"], list)
-        assert len(serialized["structural_anchors"]) == 1
-        assert serialized["structural_anchors"][0]["price"] == 49000.0
-        assert serialized["structural_anchors"][0]["pivot_type"] == "swing_low"
+        assert isinstance(
+            serialized["structural_anchors"], list
+        ), f"Expected structural_anchors as list, got {type(serialized['structural_anchors'])}"
+        assert (
+            len(serialized["structural_anchors"]) == 1
+        ), f"Expected 1 anchor, got {len(serialized['structural_anchors'])}"
+        assert (
+            serialized["structural_anchors"][0]["price"] == 49000.0
+        ), f"Expected price=49000.0, got {serialized['structural_anchors'][0].get('price')!r}"
 
     def test_bq_serialization_empty_defaults(self):
         """Ensure defaults play nicely with BigQuery missing/empty constraints."""
@@ -523,14 +648,51 @@ class TestFactTheoreticalSignal:
             asset_class=AssetClass.CRYPTO,
             side=OrderSide.BUY,
             entry_price=50000.0,
+            pattern_name="bullish_engulfing",
             suggested_stop=48000.0,
             valid_until=datetime(2024, 1, 16, tzinfo=timezone.utc),
             status=SignalStatus.EXPIRED,
+            trade_type="FILTERED",
             created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
         )
 
         serialized = signal.model_dump(mode="json")
-        assert serialized.get("confluence_snapshot") is None
-        assert serialized.get("harmonic_metadata") is None
-        assert serialized.get("structural_anchors") is None
-        assert serialized.get("rejection_metadata") is None
+        assert (
+            serialized.get("confluence_snapshot") is None
+        ), f"Expected None, got {serialized.get('confluence_snapshot')!r}"
+        assert (
+            serialized.get("harmonic_metadata") is None
+        ), f"Expected None, got {serialized.get('harmonic_metadata')!r}"
+        assert (
+            serialized.get("structural_anchors") is None
+        ), f"Expected None, got {serialized.get('structural_anchors')!r}"
+        assert (
+            serialized.get("rejection_metadata") is None
+        ), f"Expected None, got {serialized.get('rejection_metadata')!r}"
+        # New fields should also be None
+        assert (
+            serialized.get("theoretical_pnl_usd") is None
+        ), f"Expected None, got {serialized.get('theoretical_pnl_usd')!r}"
+        assert (
+            serialized.get("linked_trade_id") is None
+        ), f"Expected None, got {serialized.get('linked_trade_id')!r}"
+        assert (
+            serialized.get("distance_to_trigger_pct") is None
+        ), f"Expected None, got {serialized.get('distance_to_trigger_pct')!r}"
+
+    def test_factory_produces_valid_model(self):
+        """Verify that FactTheoreticalSignalFactory.build() produces a valid model."""
+        from tests.factories import FactTheoreticalSignalFactory
+
+        signal = FactTheoreticalSignalFactory.build()
+
+        assert signal.signal_id is not None, "signal_id must not be None"
+        assert (
+            signal.strategy_id == "BULLISH_ENGULFING"
+        ), f"Expected strategy_id='BULLISH_ENGULFING', got {signal.strategy_id!r}"
+        assert (
+            signal.trade_type == "FILTERED"
+        ), f"Expected trade_type='FILTERED', got {signal.trade_type!r}"
+        assert (
+            signal.theoretical_pnl_usd is None
+        ), f"Expected theoretical_pnl_usd=None, got {signal.theoretical_pnl_usd!r}"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 from crypto_signals.domain.schemas import (
     AssetClass,
+    FactTheoreticalSignal,
     OrderSide,
     Position,
     Signal,
@@ -134,3 +135,58 @@ class PositionFactory(ModelFactory[Position]):
     realized_pnl_usd = 0.0
     realized_pnl_pct = 0.0
     delete_at = None
+
+
+class FactTheoreticalSignalFactory(ModelFactory[FactTheoreticalSignal]):
+    __model__ = FactTheoreticalSignal
+
+    @classmethod
+    def ds(cls) -> date:
+        return date(2025, 1, 15)
+
+    strategy_id = "BULLISH_ENGULFING"
+    symbol = "BTC/USD"
+    asset_class = AssetClass.CRYPTO
+    side = OrderSide.BUY
+    status = SignalStatus.WAITING
+    trade_type = "FILTERED"
+    entry_price = 50000.0
+    pattern_name = "BULLISH_ENGULFING"
+    suggested_stop = 48000.0
+
+    @classmethod
+    def valid_until(cls) -> datetime:
+        return datetime(2025, 1, 16, 12, 0, tzinfo=timezone.utc)
+
+    @classmethod
+    def created_at(cls) -> datetime:
+        return datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+
+    @classmethod
+    def confluence_factors(cls) -> List[str]:
+        return []
+
+    # ALL optional fields = None (prevents polyfactory random values)
+    doc_id = None
+    take_profit_1 = None
+    take_profit_2 = None
+    take_profit_3 = None
+    exit_reason = None
+    rejection_reason = None
+    pattern_classification = None
+    pattern_duration_days = None
+    pattern_span_days = None
+    conviction_tier = None
+    structural_context = None
+    confluence_snapshot = None
+    harmonic_metadata = None
+    rejection_metadata = None
+    structural_anchors = None
+    theoretical_exit_price = None
+    theoretical_exit_reason = None
+    theoretical_exit_time = None
+    theoretical_pnl_usd = None
+    theoretical_pnl_pct = None
+    theoretical_fees_usd = None
+    distance_to_trigger_pct = None
+    linked_trade_id = None


### PR DESCRIPTION
## Problem

Fixes #360

Three separate schemas (`FactRejectedSignal`, `ExpiredSignal`, + missing `INVALIDATED`) make cross-outcome backtesting analytics impossible. Every analyst query that tries to answer "show me all signals that fired in Q1" requires 3+ UNION ALL joins. The existing `FactTheoreticalSignal` was a skeleton with only ~15 fields — far short of what the unified `BacktestArchivalPipeline` (Issue #361) requires.

## Solution

Expanded `FactTheoreticalSignal` into the comprehensive unified backtesting schema (~40 fields) that captures ALL signal outcomes. Added bidirectional JSON blob handling via `@model_validator(mode="before")` for input coercion + existing `@field_serializer` for BQ output. Legacy schemas preserved with DEPRECATED docstrings for backward compatibility.

### Key Decisions
- **Dict ↔ JSON bidirectional**: The `@model_validator` parses JSON string inputs to dicts for Python-side access, while `@field_serializer` converts back to JSON strings for `model_dump(mode="json")` → BigQuery insertion
- **DEPRECATED, not deleted**: `ExpiredSignal` and `FactRejectedSignal` kept intact until `BacktestArchivalPipeline` (#361) is validated in prod
- **Factory-first testing**: All tests use `FactTheoreticalSignalFactory.build()` with override-only pattern per KB [2026-03-02]

## Changes

- **`src/crypto_signals/domain/schemas.py`**: Expanded `FactTheoreticalSignal` with outcome classification, signal params, structural metadata, theoretical P&L, near-miss, and FK fields. Added `@model_validator` for JSON coercion. Deprecated `ExpiredSignal` + `FactRejectedSignal`
- **`tests/factories.py`**: Added `FactTheoreticalSignalFactory` with all optional fields = `None`
- **`tests/domain/test_schemas.py`**: 9 parametrized tests covering all 4 signal outcome scenarios (rejected/expired/invalidated/executed), dict/JSON coercion, BQ serialization, and factory validation
- **`docs/designs/analytics_gap_analysis.md`**: Added consolidated field list table with 40 fields

## Verification

- [x] Unit Tests passed (622 passed, 0 failed, 70% coverage)
- [x] Type checking passed (mypy clean)
- [x] Linting passed (ruff clean)
- [x] Pre-commit hooks passed
- [x] Security scan clean (no secrets/PII)
