### PR TITLE
Setup Supabase Auth & Users Schema

### DIFF
--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -15,6 +15,8 @@ This guide documents the complete production deployment process for Crypto Senti
   - [1.3. Initialize Firestore](#13-initialize-firestore)
   - [1.4. Configure Firestore Indexes](#14-configure-firestore-indexes)
   - [1.5. Initialize BigQuery](#15-initialize-bigquery)
+   - [1.6. Initialize Supabase (Auth & Users)](#16-initialize-supabase-auth--users)
+   - [1.7. Phase 1 Authentication (OAuth & Supabase)](#17-phase-1-authentication-oauth--supabase)
 - [2. Service Account Configuration](#2-service-account-configuration)
   - [2.1. Create Custom Service Account (Recommended)](#21-create-custom-service-account-recommended)
   - [2.2. Grant Required Permissions](#22-grant-required-permissions)
@@ -335,7 +337,32 @@ bq ls
 
 ---
 
-### 1.6. Phase 1 Authentication (OAuth & Supabase)
+### 1.6. Initialize Supabase (Auth & Users)
+
+The React frontend requires Supabase for user authentication and profile management.
+
+**1. Create user_profiles schema:**
+Run the following SQL in the Supabase SQL Editor:
+
+```sql
+-- Migration Script for Supabase Auth & user_profiles schema
+-- Located at: scripts/supabase_schema.sql
+
+-- Creates the user_profiles table and automated triggers
+-- (Copy and paste the content of scripts/supabase_schema.sql)
+```
+
+**2. Configure Auth Providers:**
+Follow the steps in [Section 1.7 Phase 1 Authentication](#17-phase-1-authentication-oauth--supabase) to enable Google and GitHub OAuth.
+
+**3. Configure Environment Variables:**
+Add the following to your `.env` or Secret Manager:
+- `NEXT_PUBLIC_SUPABASE_URL`: Found in **Project Settings > API > Project URL**
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Found in **Project Settings > API > API Keys (anon public)**
+
+---
+
+### 1.7. Phase 1 Authentication (OAuth & Supabase)
 
 Required for the Stitch React Frontend. Because Google and GitHub forbid automated API registration via third-party agents, these steps must be performed manually.
 

--- a/scripts/supabase_schema.sql
+++ b/scripts/supabase_schema.sql
@@ -1,0 +1,63 @@
+-- Migration Script for Supabase Auth & user_profiles schema
+-- This script sets up the user metadata table and triggers for automated profile creation.
+
+-- =========================================================================================
+-- 1. User Profiles Table
+-- =========================================================================================
+CREATE TABLE IF NOT EXISTS public.user_profiles (
+    id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    email TEXT UNIQUE NOT NULL,
+    full_name TEXT,
+    avatar_url TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- =========================================================================================
+-- 2. Automated Profile Creation Trigger
+-- =========================================================================================
+
+-- Function to handle new user signups
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO public.user_profiles (id, email, full_name, avatar_url)
+    VALUES (
+        NEW.id,
+        NEW.email,
+        NEW.raw_user_meta_data->>'full_name',
+        NEW.raw_user_meta_data->>'avatar_url'
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Trigger to call function on signup
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- =========================================================================================
+-- 3. Row Level Security (RLS) Policies
+-- =========================================================================================
+
+-- Enable RLS
+ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own profile
+DROP POLICY IF EXISTS "Users can view their own profile" ON public.user_profiles;
+CREATE POLICY "Users can view their own profile"
+    ON public.user_profiles
+    FOR SELECT
+    USING (auth.uid() = id);
+
+-- Policy: Users can update their own profile
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.user_profiles;
+CREATE POLICY "Users can update their own profile"
+    ON public.user_profiles
+    FOR UPDATE
+    USING (auth.uid() = id);
+
+-- Policy: Allow profile insertion via trigger (system level)
+-- Since the function uses SECURITY DEFINER, it runs as the user who created it (owner).
+-- No extra policy needed for the trigger itself if owner has permissions.


### PR DESCRIPTION
Implemented the foundational Supabase Authentication and User Schema for the React frontend. This include:
- A `user_profiles` table linked to `auth.users`.
- A PostgreSQL trigger to automatically create profiles on signup.
- Row Level Security (RLS) policies to ensure users can only access their own data.
- Comprehensive deployment documentation for infrastructure setup.

Fixes #382

---
*PR created automatically by Jules for task [846967224106167222](https://jules.google.com/task/846967224106167222) started by @lagarcess*